### PR TITLE
fix: remove activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # atom-ide-console
+
 Aggregate and display output from various sources and provide an user interface for REPL-like functionality.
 
 ![Build Status (Github Actions)](https://github.com/atom-ide-community/atom-ide-console/workflows/CI/badge.svg)
@@ -7,12 +8,12 @@ Aggregate and display output from various sources and provide an user interface 
 [![apm](https://img.shields.io/apm/v/atom-ide-console.svg)](https://github.com/atom-ide-community/atom-ide-console)
 
 ## Usage
+
 This is a work in progress. This is only tested with atom-ide-javascript and atom-ide-debugger. Once you install both, you can debug Node programs and see the result in the console.
 
 Currently, you should follow this GIF:
 
 ![debugger](https://user-images.githubusercontent.com/16418197/95936245-be136980-0d9a-11eb-9641-6c555ebd0662.gif)
-
 
 ## Roadmap
 

--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,7 @@ let _disposables: UniversalDisposable
 let _rawState: ?Object
 let _store: Store
 let _nextMessageId: number
+let activation // a variable that shows if atom-ide-console is disposed or not
 
 export function activate(rawState: ?Object) {
   _rawState = rawState
@@ -74,6 +75,7 @@ export function activate(rawState: ?Object) {
       .subscribe(_store.dispatch),
     _registerCommandAndOpener()
   )
+  activation = true
 }
 
 export function _getStore(): Store {
@@ -87,6 +89,7 @@ export function _getStore(): Store {
 
 export function deactivate() {
   _disposables.dispose()
+  activation = null
 }
 
 export function consumeToolBar(getToolBar: toolbar$GetToolbar): void {
@@ -122,7 +125,6 @@ export function consumeWatchEditor(watchEditor: atom$AutocompleteWatchEditor): I
 }
 
 export function provideAutocomplete(): atom$AutocompleteProvider {
-  const activation = this
   return {
     labels: ["nuclide-console"],
     selector: "*",
@@ -177,12 +179,6 @@ export function deserializeConsole(state: ConsolePersistedState): Console {
  * there aren't any remaining messages from the source).
  */
 export function provideConsole(): ConsoleService {
-  // Create a local, nullable reference so that the service consumers don't keep the Activation
-  // instance in memory.
-  let activation = this
-  _disposables.add(() => {
-    activation = null
-  })
 
   // Creates an objet with callbacks to request manipulations on the current
   // console message entry.
@@ -296,12 +292,6 @@ export function provideConsole(): ConsoleService {
 }
 
 export function provideRegisterExecutor(): RegisterExecutorFunction {
-  // Create a local, nullable reference so that the service consumers don't keep the Activation
-  // instance in memory.
-  let activation = this
-  _disposables.add(() => {
-    activation = null
-  })
 
   return (executor) => {
     invariant(activation != null, "Executor registration attempted after deactivation")

--- a/src/main.js
+++ b/src/main.js
@@ -133,7 +133,7 @@ export function provideAutocomplete(): atom$AutocompleteProvider {
     async getSuggestions(request) {
       // History provides suggestion only on exact match to current input.
       const prefix = request.editor.getText()
-      const history = activation._getStore().getState().history
+      const history = _getStore().getState().history
       // Use a set to remove duplicates.
       const seen = new Set(history)
       return Array.from(seen)
@@ -186,8 +186,7 @@ export function provideConsole(): ConsoleService {
     const findMessage = () => {
       invariant(activation != null)
       return nullthrows(
-        activation
-          ._getStore()
+          _getStore()
           .getState()
           .incompleteRecords.find((r) => r.messageId === messageId)
       )
@@ -219,14 +218,14 @@ export function provideConsole(): ConsoleService {
 
   const updateMessage = (messageId: string, appendText: ?string, overrideLevel: ?Level, setComplete: boolean) => {
     invariant(activation != null)
-    activation._getStore().dispatch(Actions.recordUpdated(messageId, appendText, overrideLevel, setComplete))
+    _getStore().dispatch(Actions.recordUpdated(messageId, appendText, overrideLevel, setComplete))
     return createToken(messageId)
   }
 
   return (sourceInfo: SourceInfo) => {
     invariant(activation != null)
     let disposed
-    activation._getStore().dispatch(Actions.registerSource(sourceInfo))
+    _getStore().dispatch(Actions.registerSource(sourceInfo))
     const console = {
       // TODO: Update these to be (object: any, ...objects: Array<any>): void.
       log(object: string): ?RecordToken {
@@ -272,18 +271,18 @@ export function provideConsole(): ConsoleService {
           token = createToken(record.messageId)
         }
 
-        activation._getStore().dispatch(Actions.recordReceived(record))
+        _getStore().dispatch(Actions.recordReceived(record))
         return token
       },
       setStatus(status: ConsoleSourceStatus): void {
         invariant(activation != null && !disposed)
-        activation._getStore().dispatch(Actions.updateStatus(sourceInfo.id, status))
+        _getStore().dispatch(Actions.updateStatus(sourceInfo.id, status))
       },
       dispose(): void {
         invariant(activation != null)
         if (!disposed) {
           disposed = true
-          activation._getStore().dispatch(Actions.removeSource(sourceInfo.id))
+          _getStore().dispatch(Actions.removeSource(sourceInfo.id))
         }
       },
     }
@@ -295,10 +294,10 @@ export function provideRegisterExecutor(): RegisterExecutorFunction {
 
   return (executor) => {
     invariant(activation != null, "Executor registration attempted after deactivation")
-    activation._getStore().dispatch(Actions.registerExecutor(executor))
+    _getStore().dispatch(Actions.registerExecutor(executor))
     return new UniversalDisposable(() => {
       if (activation != null) {
-        activation._getStore().dispatch(Actions.unregisterExecutor(executor))
+        _getStore().dispatch(Actions.unregisterExecutor(executor))
       }
     })
   }

--- a/src/main.js
+++ b/src/main.js
@@ -179,14 +179,13 @@ export function deserializeConsole(state: ConsolePersistedState): Console {
  * there aren't any remaining messages from the source).
  */
 export function provideConsole(): ConsoleService {
-
   // Creates an objet with callbacks to request manipulations on the current
   // console message entry.
   const createToken = (messageId: string) => {
     const findMessage = () => {
       invariant(activation != null)
       return nullthrows(
-          _getStore()
+        _getStore()
           .getState()
           .incompleteRecords.find((r) => r.messageId === messageId)
       )
@@ -291,7 +290,6 @@ export function provideConsole(): ConsoleService {
 }
 
 export function provideRegisterExecutor(): RegisterExecutorFunction {
-
   return (executor) => {
     invariant(activation != null, "Executor registration attempted after deactivation")
     _getStore().dispatch(Actions.registerExecutor(executor))


### PR DESCRIPTION
Because we [export the functions directly](https://github.com/atom-ide-community/atom-ide-console/commit/ea1df07063cd6dcecc5baf23c44e109aa43dfaff), we don't need this anymore.

This is not a proper way for doing memory management. Setting activation to null a couple of times is the exact sign of double free. Although JavaScript is garbage collected, we should not do this.